### PR TITLE
Fix compilation errors for gcc 9.4.0 and older

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -136,7 +136,7 @@ void blockdef_update_collisions(Vector2 position, ScrBlockdef* blockdef, bool ed
         Rectangle arg_size;
 
         switch (cur->type) {
-        case INPUT_TEXT_DISPLAY:
+        case INPUT_TEXT_DISPLAY: ;
             ScrMeasurement ms = cur->data.stext.editor_ms;
             if (editing) {
                 arg_size.x = cursor.x;
@@ -173,7 +173,7 @@ void blockdef_update_collisions(Vector2 position, ScrBlockdef* blockdef, bool ed
                 hover_info.editor.blockdef_input = i;
             }
             break;
-        default:
+        default: ;
             Vector2 size = MeasureTextEx(font_cond, "NODEF", BLOCK_TEXT_SIZE, 0.0);
             width = size.x;
             break;
@@ -236,7 +236,7 @@ void block_update_collisions(Vector2 position, ScrBlock* block) {
                     break;
                 }
                 break;
-            case ARGUMENT_BLOCK:
+            case ARGUMENT_BLOCK: ;
                 Vector2 block_pos;
                 block_pos.x = cursor.x;
                 block_pos.y = cursor.y + (block->ms.placement == PLACEMENT_VERTICAL ? 0 : block_size.height / 2 - block->arguments[arg_id].ms.size.y / 2); 
@@ -341,7 +341,7 @@ void block_update_collisions(Vector2 position, ScrBlock* block) {
 
             arg_id++;
             break;
-        default:
+        default: ;
             Vector2 size = MeasureTextEx(font_cond, "NODEF", BLOCK_TEXT_SIZE, 0.0);
             width = size.x;
             height = size.y;

--- a/src/measure.c
+++ b/src/measure.c
@@ -124,7 +124,7 @@ void update_measurements(ScrBlock* block, ScrPlacementStrategy placement) {
         case INPUT_ARGUMENT:
             switch (block->arguments[arg_id].type) {
             case ARGUMENT_CONST_STRING:
-            case ARGUMENT_TEXT:
+            case ARGUMENT_TEXT: ;
                 ScrMeasurement string_ms = measure_input_box(block->arguments[arg_id].data.text);
                 block->arguments[arg_id].ms = string_ms;
                 ms = string_ms;
@@ -148,7 +148,7 @@ void update_measurements(ScrBlock* block, ScrPlacementStrategy placement) {
             block->arguments[arg_id].ms = ms;
             arg_id++;
             break;
-        case INPUT_BLOCKDEF_EDITOR:
+        case INPUT_BLOCKDEF_EDITOR: ;
             ScrBlockdef* blockdef = block->arguments[arg_id].data.blockdef;
             blockdef_update_measurements(blockdef, hover_info.editor.edit_blockdef == blockdef);
             ScrMeasurement editor_ms = block->arguments[arg_id].data.blockdef->ms;

--- a/src/render.c
+++ b/src/render.c
@@ -184,7 +184,9 @@ void draw_blockdef(Vector2 position, ScrBlockdef* blockdef, bool editing) {
             break;
         case INPUT_BLOCKDEF_EDITOR:
             assert(false && "Unimplemented");
-            break; default: Vector2 size = MeasureTextEx(font_cond, "NODEF", BLOCK_TEXT_SIZE, 0.0);
+            break;
+        default: ;
+            Vector2 size = MeasureTextEx(font_cond, "NODEF", BLOCK_TEXT_SIZE, 0.0);
             width = size.x;
             arg_pos.y += block_size.height * 0.5 - BLOCK_TEXT_SIZE * 0.5;
 
@@ -353,7 +355,7 @@ void draw_block(Vector2 position, ScrBlock* block, bool force_outline, bool forc
 
             arg_id++;
             break;
-        default:
+        default: ;
             Vector2 size = MeasureTextEx(font_cond, "NODEF", BLOCK_TEXT_SIZE, 0.0);
             width = size.x;
             height = size.y;

--- a/src/save.c
+++ b/src/save.c
@@ -393,7 +393,7 @@ bool load_blockdef_input(SaveArena* save, ScrInput* input) {
     input->type = type;
 
     switch (input->type) {
-    case INPUT_TEXT_DISPLAY:
+    case INPUT_TEXT_DISPLAY: ;
         unsigned int text_len;
         char* text = save_read_array(save, sizeof(char), &text_len);
         if (!text) return false;
@@ -406,7 +406,7 @@ bool load_blockdef_input(SaveArena* save, ScrInput* input) {
         for (char* str = text; *str; str++) vector_add(&input->data.stext.text, *str);
         vector_add(&input->data.stext.text, 0);
         break;
-    case INPUT_ARGUMENT:
+    case INPUT_ARGUMENT: ;
         ScrInputArgumentConstraint constr; 
         if (!save_read_varint(save, (unsigned int*)&constr)) return false;
 
@@ -484,7 +484,7 @@ bool load_block_argument(SaveArena* save, ScrArgument* arg) {
 
     switch (arg_type) {
     case ARGUMENT_TEXT:
-    case ARGUMENT_CONST_STRING:
+    case ARGUMENT_CONST_STRING: ;
         unsigned int text_id;
         if (!save_read_varint(save, &text_id)) return false;
 
@@ -492,13 +492,13 @@ bool load_block_argument(SaveArena* save, ScrArgument* arg) {
         for (char* str = (char*)save_block_ids[text_id]; *str; str++) vector_add(&arg->data.text, *str);
         vector_add(&arg->data.text, 0);
         break;
-    case ARGUMENT_BLOCK:
+    case ARGUMENT_BLOCK: ;
         ScrBlock block;
         if (!load_block(save, &block)) return false;
         
         arg->data.block = block;
         break;
-    case ARGUMENT_BLOCKDEF:
+    case ARGUMENT_BLOCKDEF: ;
         unsigned int blockdef_id;
         if (!save_read_varint(save, &blockdef_id)) return false;
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -517,7 +517,7 @@ bool exec_block(ScrExec* exec, ScrBlock block, ScrData* block_return, bool from_
                     },
                 });
                 break;
-            case ARGUMENT_BLOCK:
+            case ARGUMENT_BLOCK: ;
                 ScrData arg_return;
                 if (!exec_block(exec, block_arg.data.block, &arg_return, false, false, (ScrData) {0})) return false;
                 arg_stack_push_arg(exec, arg_return);


### PR DESCRIPTION
Observed many compilation errors while compilation by gcc 9.4.0 (Ubuntu 20.04).
Ex:
src/vm.h:521:17: error: a label can only be part of a statement and a declaration is not a statement

According to previous C standards(before c2x): forbidden to put a label immediately before a declaration.
As workaround the empty statement can be added before a label.