### PR TITLE
ci: clean GitHub Actions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,10 +1,18 @@
 name: Makefile CI
 
 on:
-    push:
-        branches: [ "main" ]
-    pull_request:
-        branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+      - "CHANGELOG.md"
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+      - "CHANGELOG.md"
 
 jobs:
     build-windows:
@@ -26,15 +34,10 @@ jobs:
               with:
                 msystem: UCRT64
                 update: true
-                install: >-
-                    mingw-w64-ucrt-x86_64-gcc
-                    mingw-w64-ucrt-x86_64-llvm
-                    make
-                    gettext
+                install: mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-llvm make gettext
 
             - name: Setup windres
-              run: |
-                ln -sf "${MSYSTEM_PREFIX}/bin/windres.exe" "${MSYSTEM_PREFIX}/bin/x86_64-w64-mingw32-windres"
+              run: ln -sf "${MSYSTEM_PREFIX}/bin/windres.exe" "${MSYSTEM_PREFIX}/bin/x86_64-w64-mingw32-windres"
 
             - name: Build project (With compiler)
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,8 +182,7 @@ jobs:
           pattern: 'scrap-*'
       
       - name: Generate release notes
-        run: |
-          python "$GITHUB_WORKSPACE/.github/generate_notes.py" > release_notes.md
+        run: python "$GITHUB_WORKSPACE/.github/generate_notes.py" > release_notes.md
 
       - name: Create a draft release
         env:


### PR DESCRIPTION
- Avoid Makefile CI running on changes to README.md, LICENSE, and CHANGELOG.md
- Simplify MSYS2 package install into a single line
- Convert multi-line shell commands to single-line where possible

This should be the last pull request for now, as all intended updates have been added.
